### PR TITLE
Only no-op if the chosen tab is the selected tab _in the focused window_...

### DIFF
--- a/background.js
+++ b/background.js
@@ -137,13 +137,17 @@ omnibox.onInputEntered.addListener(function(url) {
   });
 
   chrome.tabs.get(tabId, function(tab) {
-    if (tab && !tab.selected) {
-      chrome.tabs.update(tabId, { active: true },
-          function() {
-        chrome.windows.update(tab.windowId, { focused: true });
+    if (tab) {
+      chrome.windows.get(tab.windowId, function (window) {
+        if (!(window.focused && tab.selected)) {
+          chrome.tabs.update(tabId, { active: true }, function() {
+            chrome.windows.update(tab.windowId, { focused: true });
+          });
+        }
       });
     }
   });
+
 });
 
 omnibox.onInputCancelled.addListener(function() {

--- a/background.js
+++ b/background.js
@@ -116,11 +116,16 @@ omnibox.onInputChanged.addListener(function(text, suggest) {
       };
     });
 
+    if (suggestions && suggestions.length == 1 && text.length >= 4 && (""+localStorage["autoswitch"] == "true")) {
+        tabsearch_onInputEntered(suggestions[0].content);
+        return;
+    }
+
     suggest(suggestions);
   });
 });
 
-omnibox.onInputEntered.addListener(function(url) {
+var tabsearch_onInputEntered = function(url) {
   var tabId = url.match(/#(\d+)$/);
   if (tabId)
     tabId = parseInt(tabId[1]);
@@ -148,7 +153,9 @@ omnibox.onInputEntered.addListener(function(url) {
     }
   });
 
-});
+};
+
+omnibox.onInputEntered.addListener(tabsearch_onInputEntered);
 
 omnibox.onInputCancelled.addListener(function() {
   topMatch = -1;

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
     "permissions": [
         "tabs"
     ],
+    "options_page": "options.html",
     "omnibox": {
         "keyword": "tab"
     },

--- a/options.html
+++ b/options.html
@@ -1,0 +1,14 @@
+<html>
+<head><title>Search Tab in Chrome's Omnibox Options</title></head>
+
+<body>
+
+Automatically switch to unambiguous tab: <input id="autoswitch" type="checkbox">
+<br>
+<div id="status"></div>
+<button id="save">Save</button>
+</body>
+
+<script src="options.js"></script>
+
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,22 @@
+// Saves options to localStorage.
+function save_options() {
+  var autoswitch = document.getElementById("autoswitch").checked;
+  localStorage["autoswitch"] = autoswitch;
+
+  // Update status to let user know options were saved.
+  var status = document.getElementById("status");
+  status.innerHTML = "Options Saved.";
+  setTimeout(function() {
+    status.innerHTML = "";
+  }, 750);
+}
+
+// Restores select box state to saved value from localStorage.
+function restore_options() {
+  var autoswitch = localStorage["autoswitch"]; 
+
+  document.getElementById("autoswitch").checked = (""+autoswitch) == "true";
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.querySelector('#save').addEventListener('click', save_options);


### PR DESCRIPTION
.... This fixes the bug whereby you couldn't switch to tabs which were the selected tab in a different window than the one currently with focus.